### PR TITLE
style: address a few style issues

### DIFF
--- a/src/ngx_gzip_setter.h
+++ b/src/ngx_gzip_setter.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+// Author: kspoelstra@we-amp.com (Kees Spoelstra)
+
 /*
  * NgxGZipSetter sets up gzip for pagespeed
  * with the following configuration:
@@ -45,25 +47,25 @@
  * fail.
  */
 
-// Author: kspoelstra@we-amp.com (Kees Spoelstra)
+#ifndef NGX_GZIP_SETTER_H_
+#define NGX_GZIP_SETTER_H_
 
-#ifndef SRC_NGX_GZIP_SETTER_H_
-#define SRC_NGX_GZIP_SETTER_H_
 extern "C" {
-#include <ngx_config.h>
-#include <ngx_core.h>
-#include <ngx_http.h>
+  #include <ngx_config.h>
+  #include <ngx_core.h>
+  #include <ngx_http.h>
 }
 
 #include <vector>
+
+#include "net/instaweb/util/public/basictypes.h"
 
 using std::vector;
 
 namespace net_instaweb {
 
-// We need this class because configuration for gzip
-// is in different modules, so just saving the command
-// will not work.
+// We need this class because configuration for gzip is in different modules, so
+// just saving the command will not work.
 class ngx_command_ctx {
  public:
   ngx_command_ctx():command_(NULL), module_(NULL) {
@@ -81,6 +83,7 @@ enum gzs_init_result {
     kInitGZipSecondarySignatureMismatch,
     kInitGZipSecondaryMissing
 };
+
 enum gzs_enable_result {
     kEnableGZipOk,
     kEnableGZipPartial,
@@ -110,11 +113,13 @@ class NgxGZipSetter {
   gzs_enable_result EnableGZipForLocation(ngx_conf_t *cf);
   void AddGZipHTTPTypes(ngx_conf_t *cf);
   void RollBackAndDisable();
+
+  DISALLOW_COPY_AND_ASSIGN(NgxGZipSetter);
 };
 
-// global access to g_gzip_setter
-// TODO(kspoelstra) could be moved to a pagespeed module context
+// TODO(kspoelstra): Could be moved to a pagespeed module context.
 extern NgxGZipSetter g_gzip_setter;
+
 }  // namespace net_instaweb
 
-#endif  // SRC_NGX_GZIP_SETTER_H_
+#endif  // NGX_GZIP_SETTER_H_

--- a/src/ngx_pagespeed.cc
+++ b/src/ngx_pagespeed.cc
@@ -30,6 +30,7 @@
 
 #include "ngx_base_fetch.h"
 #include "ngx_caching_headers.h"
+#include "ngx_gzip_setter.h"
 #include "ngx_list_iterator.h"
 #include "ngx_message_handler.h"
 #include "ngx_rewrite_driver_factory.h"
@@ -71,8 +72,6 @@
 #include "net/instaweb/util/stack_buffer.h"
 #include "pagespeed/kernel/thread/pthread_shared_mem.h"
 #include "pagespeed/kernel/html/html_keywords.h"
-
-#include "ngx_gzip_setter.h"
 
 extern ngx_module_t ngx_pagespeed;
 
@@ -606,9 +605,6 @@ char* ps_configure(ngx_conf_t* cf,
   CHECK(n_args <= NGX_PAGESPEED_MAX_ARGS);
   StringPiece args[NGX_PAGESPEED_MAX_ARGS];
 
-
-
-
   ngx_str_t* value = static_cast<ngx_str_t*>(cf->args->elts);
   ngx_uint_t i;
   for (i = 0 ; i < n_args ; i++) {
@@ -616,7 +612,7 @@ char* ps_configure(ngx_conf_t* cf,
   }
 
   // TODO(kspoelstra): could be moved into the config handler for ngx
-  if (n_args==1 && args[0].compare("on") == 0) {
+  if (n_args == 1 && args[0].compare("on") == 0) {
     // safe to call if the setter is disabled
     g_gzip_setter.EnableGZipForLocation(cf);
   }
@@ -2746,15 +2742,13 @@ ngx_int_t ps_etag_filter_init(ngx_conf_t* cf) {
   return NGX_OK;
 }
 
-
-// kspoelstra: called before configuration.
+// Called before configuration.
 ngx_int_t ps_pre_init(ngx_conf_t *cf) {
   // Setup an intervention setter for gzip configuration and check
   // gzip configuration command signatures.
   g_gzip_setter.Init();
   return NGX_OK;
 }
-
 
 ngx_int_t ps_init(ngx_conf_t* cf) {
   // Only put register pagespeed code to run if there was a "pagespeed"

--- a/test/nginx_system_test.sh
+++ b/test/nginx_system_test.sh
@@ -82,9 +82,7 @@ function keepalive_test() {
   done
 
   # Filter the curl output from unimportant messages
-  # kspoelstra: 
-  # Found bundle for host is emitted by new versions
-  # of curl
+  # 'Found bundle for host...' is emitted by newer versions of curl.
   OUT=$(cat "$TEST_TMP/$CURL_LOG_FILE"\
     | grep -v "^[<>]"\
     | grep -v "^{ \\[data not shown"\

--- a/test/pagespeed_test.conf.template
+++ b/test/pagespeed_test.conf.template
@@ -865,30 +865,9 @@ http {
 
   keepalive_timeout  65;
 
-  # With the NgxGZipSetter we do not need to setup gzip
-  # TODO(kspoelstra) we should run tests to ensure that
-  # NgxGZipSetter works correctly if there is a explicit
-  # gzip configuration
-
-  # set up gzip
-  #gzip  on;
-  #gzip_vary on;
-  # Turn on gzip for all content types that should benefit from it.
-  #gzip_types application/ecmascript;
-  #gzip_types application/javascript;
-  #gzip_types application/json;
-  #gzip_types application/pdf;
-  #gzip_types application/postscript;
-  #gzip_types application/x-javascript;
-  #gzip_types image/svg+xml;
-  #gzip_types text/css;
-  #gzip_types text/csv;
-  ## "gzip_types text/html" is assumed.
-  #gzip_types text/javascript;
-  #gzip_types text/plain;
-  #gzip_types text/xml;
-
-  #gzip_http_version 1.0;
+  # With the NgxGZipSetter we do not need to setup gzip.
+  # TODO(kspoelstra): We should run tests to ensure that NgxGZipSetter works
+  # correctly if there is a explicit gzip configuration.
 
   types {
     text/html                             html htm shtml;


### PR DESCRIPTION
- Fix cpplint complaints
- Utilize 80 cols in a few comments / function arg lists, to be
  more consistent with the rest of the codebase
- Header guard: SRC_NGX_GZIP_SETTER_H_ -> NGX_GZIP_SETTER_H_
  Per style guide this was correct, but somehow the rest of the
  code base is wrong :-) Jeff has disabled the header guard lint
  checks, so probably this was by intent.
- Most importantly: changed strncpy -> snprintf as recommended
  by cpplint - please take a good look!
- Change todo format: 'TODO(kspoelstra) foo bar' ->
  'TODO(kspoelstra): foo bar'.
