### PR TITLE
docs(readme): drop 14-day-trial copy; 1.1→1.15; nginx is GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 **ngx_pagespeed is maintained again — under the [ModPageSpeed](https://modpagespeed.com/) project at We-Amp.**
 
-ngx_pagespeed was created at Google as the nginx port of mod_pagespeed. Google released its final upstream version in 2020. We-Amp picked it up. Active development continues under two product lines, both nginx-supported:
+ngx_pagespeed was created at Google as the nginx port of mod_pagespeed. Google released its final upstream version in 2020. We-Amp picked it up. Active development continues under two product lines:
 
-- **[ModPageSpeed 2.0](https://modpagespeed.com/)** — a ground-up C++23 rewrite. Available **today** as a Docker / nginx reverse-proxy and as an ASP.NET Core middleware. A bare-metal nginx module is in active development.
-- **[mod_pagespeed 1.1](https://modpagespeed.com/1.1/)** — the maintained continuation of the open-source module. Drop-in replacement for the original mod_pagespeed and ngx_pagespeed configurations, with security patches and the new Cyclone Cache. **Apache and IIS are GA today; nginx ships next.**
+- **[ModPageSpeed 2.0](https://modpagespeed.com/)** — a ground-up C++23 rewrite. Available **today** as a Docker / nginx reverse-proxy and as an ASP.NET Core middleware. A bare-metal, in-process nginx module is in active development.
+- **[mod_pagespeed 1.15](https://modpagespeed.com/1.1/)** — the maintained continuation of the open-source module (renumbered from 1.1; Google's final was 1.14.36.1). Drop-in replacement for the original mod_pagespeed and ngx_pagespeed configurations, with security patches and the new Cyclone Cache. **nginx, Apache, and IIS are GA today** — nginx ships as prebuilt, signed apt/yum packages (`nginx-module-pagespeed`) for Debian and Ubuntu. Envoy is experimental.
 
 If you are running ngx_pagespeed today, your existing configuration is compatible with both product lines.
 
 | | |
 |---|---|
 | **Try ModPageSpeed 2.0 (Docker / nginx reverse proxy)** | [Quickstart →](https://modpagespeed.com/docs/) |
-| **Run nginx today and want a drop-in upgrade** | [mod_pagespeed 1.1 →](https://modpagespeed.com/1.1/) |
-| **Get notified when nginx 1.1 / nginx 2.0 ship** | [Sign up →](https://modpagespeed.com/download/) |
-| **Pricing** | [$49/server/month — 14-day free trial →](https://modpagespeed.com/pricing/) |
+| **Run nginx today and want a drop-in upgrade** | [mod_pagespeed 1.15 →](https://modpagespeed.com/1.1/) |
+| **Get notified when the native, in-process ModPageSpeed 2.0 nginx module ships** | [Sign up →](https://modpagespeed.com/download/) |
+| **Pricing** | [$49/server/month — free to install and evaluate, license required for production →](https://modpagespeed.com/pricing/) |
 | **Support** | [Email the maintainer →](https://modpagespeed.com/contact/) |
 
 ## What you get
@@ -22,7 +22,7 @@ If you are running ngx_pagespeed today, your existing configuration is compatibl
 - **Drop-in configuration** — your existing `pagespeed` directives keep working.
 - **Security patches** for known CVEs that accumulated against the archived upstream.
 - **Cyclone Cache** — a new C++23 lock-free shared-memory cache; replaces the legacy file cache. No tuning, automatic warm-up.
-- **Active maintenance** — regular releases, modern Bazel build, pre-built binaries for amd64 and arm64.
+- **Active maintenance** — regular releases, modern Bazel build, pre-built signed apt/yum packages for amd64 and arm64.
 - **Direct maintainer support** included with every license.
 
 ## About this repository
@@ -33,7 +33,7 @@ For issues or questions about a running deployment, please [contact the maintain
 
 ## License
 
-ModPageSpeed and mod_pagespeed 1.1 are distributed under the [Business Source License 1.1](https://modpagespeed.com/license/). The first 14 days are a free trial. See [pricing](https://modpagespeed.com/pricing/) for license details.
+ModPageSpeed and mod_pagespeed 1.15 are distributed under the [Business Source License 1.1](https://modpagespeed.com/license/); source publication is planned (no date committed). You can install and run the module unlicensed to evaluate it — it fully optimizes and simply adds an `X-PageSpeed-Warn: unlicensed` response header. A commercial license is required for production use. See [pricing](https://modpagespeed.com/pricing/) for license details.
 
 ## Background
 


### PR DESCRIPTION
Fact-checked the README against live modpagespeed.com (audit + adversarial verify). Fixes customer-facing copy that had drifted:

- **No free trial.** Removed "14-day free trial" / "first 14 days are a free trial" (×2). The real model: install and run **unlicensed** to evaluate — it fully optimizes and adds an `X-PageSpeed-Warn: unlicensed` header; a commercial license is required for production.
- **Version 1.1 → 1.15.** The maintained line is `mod_pagespeed 1.15` (renumbered from 1.1). Display updated; the intentionally-frozen `/1.1/` URL paths are kept.
- **nginx is GA now.** Was "nginx ships next" — the 1.15 nginx module shipped 2026-06-04 as signed apt/yum `nginx-module-pagespeed` packages (Debian/Ubuntu, amd64+arm64). Apache/IIS/nginx all GA; Envoy experimental. Dropped the obsolete "get notified when nginx 1.1 ships" item (kept the still-valid native 2.0 nginx module notify).

Verified: no banned/stale phrases remain; `/1.1/` links preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)